### PR TITLE
Rhel support and assorted fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,14 +208,20 @@ class nslcd (
   # Insert class parameters into hash
   # This simplifies the erb template and makes
   # it less verbose
-  $parameters['uri'] = $ldap_uri_real
-  $parameters['base'] = $ldap_base_real
-  $parameters['ldap_version'] = $ldap_version_real
-  $parameters['binddn'] = $ldap_binddn_real
-  $parameters['bindpw'] = $ldap_bindpw_real
-  $parameters['ssl'] = $ldap_ssl_real
-  $parameters['tls_reqcert'] = $ldap_tls_reqcert_real
-  $parameters['scope'] = $ldap_scope_real
+  $general_parameters = {
+    'uri'          => $ldap_uri_real,
+    'base'         => $ldap_base_real,
+    'ldap_version' => $ldap_version_real,
+    'binddn'       => $ldap_binddn_real,
+    'bindpw'       => $ldap_bindpw_real,
+    'ssl'          => $ldap_ssl_real,
+    'tls_reqcert'  => $ldap_tls_reqcert_real,
+    'scope'        => $ldap_scope_real,
+    'pagesize'     => $ldap_pagesize_real,
+    'referrals'    => $ldap_referrals_real,
+  }
+
+  $full_parameters = merge($parameters, $general_parameters)
 
   # 'unmanaged' is an unknown service state
   $ensure_service = $service_status_real ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,15 @@
 #   Specifies the search scope
 #   Valid values: <tt>sub</tt>, <tt>one</tt>, <tt>base</tt>
 #
+# [*ldap_pagesize*]
+#   Specifies the LDAP paging size. Recommended with AD server.
+#   Valid values: <tt>1000</tt>
+#
+# [*ldap_referrals*]
+#   Specifies whether automatic referral chasing should be enabled.
+#   Recommended with Active Directory LDAP servers.
+#   Valid values: <tt>yes</tt>, <tt>no</tt>
+#
 # [*parameters*]
 #   Hash variable to pass to nslcd
 #   Valid values: hash, ex:  <tt>{ 'option' => 'value' }</tt>
@@ -107,6 +116,8 @@ class nslcd (
   $ldap_ssl         = 'UNDEF',
   $ldap_tls_reqcert = 'UNDEF',
   $ldap_scope       = 'UNDEF',
+  $ldap_pagesize    = 'UNDEF',
+  $ldap_referrals   = 'UNDEF',
   $parameters       = {}
 ) {
 
@@ -172,6 +183,14 @@ class nslcd (
   $ldap_scope_real = $ldap_scope ? {
     'UNDEF' => $nslcd::params::ldap_scope,
     default => $ldap_scope
+  }
+  $ldap_pagesize_real = $ldap_pagesize ? {
+    'UNDEF' => $nslcd::params::ldap_pagesize,
+    default => $ldap_pagesize
+  }
+  $ldap_referrals_real = $ldap_referrals ? {
+    'UNDEF' => $nslcd::params::ldap_referrals,
+    default => $ldap_referrals
   }
 
   # Input validation

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,7 @@
 #
 # This module has been tested on the following platforms
 # * Ubuntu LTS 10.04, 12.04
+# * RHEL 6.4
 #
 class nslcd (
   $ensure           = 'UNDEF',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,8 @@ class nslcd::params {
   $ldap_ssl = false
   $ldap_tls_reqcert = undef
   $ldap_scope = undef
+  $ldap_pagesize = 0
+  $ldap_referrals = 'yes'
 
   # This mandates which distributions are supported
   # To add support for other distributions simply add

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,15 @@ class nslcd::params {
       $config_file_mode = '0640'
       $run_dir = '/var/run/nslcd'
     }
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer': {
+       $user = 'nslcd'
+       $group = 'ldap'
+       $package = 'nss-pam-ldapd'
+       $service = 'nslcd'
+       $config_file = '/etc/nslcd.conf'
+       $config_file_mode = '0600'
+       $run_dir = '/var/run/nslcd'
+    }
     default: {
       fail("Unsupported operatingsystem ${::operatingsystem}")
     }

--- a/templates/nslcd.conf.erb
+++ b/templates/nslcd.conf.erb
@@ -9,7 +9,7 @@ uid <%= scope.lookupvar('nslcd::params::user') %>
 gid <%= scope.lookupvar('nslcd::params::group') %>
 
 # Configurable parameters
-<%- parameters.sort_by { |k,v| k }.each do |k,v|
+<%- full_parameters.sort_by { |k,v| k }.each do |k,v|
   if v != :undef
     if boolean_mapper.has_key?(v) -%>
 <%= k %> <%= boolean_mapper[v] %>


### PR DESCRIPTION
This pull request brings three unrelated changes:
- Add support for Red Hat RHEL and derivatives
- Add support for Puppet 3 (by fixing parameters hash assigment syntax).
- Covers two missing nslcd parameters (pagesize and referrals), which are import when configuring nslcd to query an Active Directory server
